### PR TITLE
Add initial Meshtastic USB Home Assistant integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# MeshtasticHA
+# Meshtastic Home Assistant Integration
+
+This repository provides a custom Home Assistant integration that discovers USB devices connected to a Home Assistant OS installation and exposes them as a sensor entity. The sensor reports how many compatible USB devices are available and adds their details as sensor attributes.
+
+## Installation
+
+1. Copy the `custom_components/meshtastic_usb` folder into the `custom_components` directory of your Home Assistant configuration. If the directory does not exist, create it.
+2. Restart Home Assistant.
+3. In Home Assistant, navigate to **Settings → Devices & Services → Integrations** and click **Add Integration**.
+4. Search for **Meshtastic USB** and complete the setup wizard.
+
+After setup, the integration will create a sensor named **Meshtastic USB devices**. The sensor value is the number of connected USB serial devices, and its attributes include detailed information for each device (port, description, vendor/product IDs, etc.).

--- a/custom_components/meshtastic_usb/__init__.py
+++ b/custom_components/meshtastic_usb/__init__.py
@@ -1,0 +1,39 @@
+"""The Meshtastic USB integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS
+from .coordinator import MeshtasticUsbCoordinator
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the Meshtastic USB component."""
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Meshtastic USB from a config entry."""
+    coordinator = MeshtasticUsbCoordinator(hass, DEFAULT_SCAN_INTERVAL)
+
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception as err:
+        raise ConfigEntryNotReady from err
+
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/meshtastic_usb/config_flow.py
+++ b/custom_components/meshtastic_usb/config_flow.py
@@ -1,0 +1,25 @@
+"""Config flow for the Meshtastic USB integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+
+from .const import DOMAIN
+
+
+class MeshtasticUsbConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Meshtastic USB."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+
+        return self.async_create_entry(title="Meshtastic USB", data={})

--- a/custom_components/meshtastic_usb/const.py
+++ b/custom_components/meshtastic_usb/const.py
@@ -1,0 +1,10 @@
+"""Constants for the Meshtastic USB integration."""
+
+from datetime import timedelta
+from homeassistant.const import Platform
+
+DOMAIN = "meshtastic_usb"
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
+
+ATTR_DEVICES = "devices"

--- a/custom_components/meshtastic_usb/coordinator.py
+++ b/custom_components/meshtastic_usb/coordinator.py
@@ -1,0 +1,78 @@
+"""Data update coordinator for the Meshtastic USB integration."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class UsbDevice:
+    """Representation of a USB serial device."""
+
+    device: str
+    description: str | None
+    hwid: str | None
+    manufacturer: str | None
+    product: str | None
+    serial_number: str | None
+    vid: int | None
+    pid: int | None
+    location: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dictionary with serializable values."""
+        data = asdict(self)
+        if self.vid is not None:
+            data["vid"] = f"0x{self.vid:04x}"
+        if self.pid is not None:
+            data["pid"] = f"0x{self.pid:04x}"
+        return {key: value for key, value in data.items() if value is not None}
+
+
+class MeshtasticUsbCoordinator(DataUpdateCoordinator[list[UsbDevice]]):
+    """Coordinator that queries connected USB serial devices."""
+
+    def __init__(self, hass: HomeAssistant, update_interval: timedelta) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN} device scanner",
+            update_interval=update_interval,
+        )
+
+    async def _async_update_data(self) -> list[UsbDevice]:
+        """Fetch the latest list of connected USB devices."""
+        return await self.hass.async_add_executor_job(_scan_usb_devices)
+
+
+def _scan_usb_devices() -> list[UsbDevice]:
+    """Return the connected USB serial devices."""
+    from serial.tools.list_ports import comports
+
+    devices: list[UsbDevice] = []
+    for port in comports():
+        devices.append(
+            UsbDevice(
+                device=port.device,
+                description=port.description,
+                hwid=port.hwid,
+                manufacturer=getattr(port, "manufacturer", None),
+                product=getattr(port, "product", None),
+                serial_number=getattr(port, "serial_number", None),
+                vid=getattr(port, "vid", None),
+                pid=getattr(port, "pid", None),
+                location=getattr(port, "location", None),
+            )
+        )
+    return devices

--- a/custom_components/meshtastic_usb/manifest.json
+++ b/custom_components/meshtastic_usb/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "meshtastic_usb",
+  "name": "Meshtastic USB",
+  "version": "0.1.0",
+  "documentation": "https://github.com/your-org/MeshtasticHA",
+  "requirements": ["pyserial==3.5"],
+  "codeowners": ["@your-github-handle"],
+  "config_flow": true,
+  "iot_class": "local_polling"
+}

--- a/custom_components/meshtastic_usb/sensor.py
+++ b/custom_components/meshtastic_usb/sensor.py
@@ -1,0 +1,44 @@
+"""Sensor platform for the Meshtastic USB integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ATTR_DEVICES, DOMAIN
+from .coordinator import MeshtasticUsbCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Meshtastic USB sensor."""
+    coordinator: MeshtasticUsbCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([MeshtasticUsbSensor(coordinator)], True)
+
+
+class MeshtasticUsbSensor(CoordinatorEntity[MeshtasticUsbCoordinator], SensorEntity):
+    """Sensor that exposes connected USB devices."""
+
+    _attr_icon = "mdi:usb-port"
+    _attr_name = "Meshtastic USB devices"
+    _attr_native_unit_of_measurement = "devices"
+    _attr_unique_id = "meshtastic_usb_devices"
+
+    @property
+    def native_value(self) -> int:
+        """Return the number of connected USB devices."""
+        return len(self.coordinator.data or [])
+
+    @property
+    def extra_state_attributes(self) -> dict[str, list[dict[str, str]]]:
+        """Return details about the connected USB devices."""
+        devices = []
+        for device in self.coordinator.data or []:
+            devices.append(device.as_dict())
+        return {ATTR_DEVICES: devices}

--- a/custom_components/meshtastic_usb/strings.json
+++ b/custom_components/meshtastic_usb/strings.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Meshtastic USB",
+        "description": "Start monitoring connected USB devices."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Meshtastic USB is already configured."
+    }
+  }
+}

--- a/custom_components/meshtastic_usb/translations/en.json
+++ b/custom_components/meshtastic_usb/translations/en.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Meshtastic USB",
+        "description": "Start monitoring connected USB devices."
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Meshtastic USB is already configured."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a custom Meshtastic USB integration that exposes connected USB devices through Home Assistant
- implement a data coordinator and sensor to surface serial device metadata
- document installation and setup instructions in the README

## Testing
- python -m compileall custom_components/meshtastic_usb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ecac88a88324a42a102680cf4159)