### PR TITLE
Expand Meshtastic integration to support TCP and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,59 @@
 # Meshtastic Home Assistant Integration
 
-This repository provides a custom Home Assistant integration for monitoring Meshtastic radios that are attached over USB. The integration automatically discovers supported adapters, connects to the radio using the Meshtastic Python API, and exposes detailed telemetry and message metadata in Home Assistant sensors.
+This repository provides a custom Home Assistant integration for managing Meshtastic radios from Home Assistant. The integration can communicate with nodes connected locally over USB serial adapters or remotely over TCP/Wi-Fi, optionally discovering nodes on the local network. Each configured node exposes rich telemetry and message metadata to Home Assistant and can be controlled through dedicated services.
 
 ## Features
 
-- Detect Meshtastic-compatible USB adapters by USB VID/PID while ignoring VirtualBox serial shims.
-- Query the radio over the official Meshtastic Python API to obtain firmware information, node identity, channels, BLE details, and mesh routing statistics.
-- Surface live radio metrics (RSSI, SNR, airtime utilisation) alongside the most recent received message, sender, and gateway information.
-- Provide multiple Home Assistant sensors so dashboards can display firmware, node ID, active channel, signal strength, and the last received text.
+- Configure multiple Meshtastic nodes, each using either USB serial or TCP (Wi-Fi) connectivity.
+- Automatically detect compatible USB adapters by VID/PID, or scan the local /24 network for Meshtastic TCP nodes before selecting one in the config flow.
+- Query the radio through the official Meshtastic Python API to gather firmware information, hardware model, node identity, channels, BLE details, mesh routing statistics, and device metrics.
+- Surface live radio metrics (RSSI, SNR, airtime utilisation, battery level/voltage, temperature, uptime) alongside the most recent received message, sender, gateway, type, and timestamp.
+- Register all sensors under a Home Assistant device with manufacturer/model/firmware metadata for easy dashboard grouping.
+- Provide Home Assistant services to send messages, reboot the node, change the primary channel, and trigger an immediate refresh.
 
 ## Created entities
 
 | Entity | Description |
 | --- | --- |
-| `sensor.meshtastic_usb_devices` | Number of detected Meshtastic-capable USB adapters with full device details in the attributes. |
-| `sensor.meshtastic_firmware` | Firmware version reported by the connected radio. |
-| `sensor.meshtastic_node_id` | Node ID of the locally connected radio. |
-| `sensor.meshtastic_channel` | Active primary channel name and a list of all configured channels in the attributes. |
+| `sensor.meshtastic_devices` | Number of configured Meshtastic nodes that are currently reachable. Attributes include the raw node details, connection information, and any connection error. |
+| `sensor.meshtastic_firmware` | Firmware version reported by the connected node. |
+| `sensor.meshtastic_node_id` | Node ID of the local radio. |
+| `sensor.meshtastic_channel` | Primary channel name with the full channel list in attributes. |
 | `sensor.meshtastic_rssi` | Current RSSI reported by the node (signal strength device class). |
-| `sensor.meshtastic_snr` | Current SNR value reported by the node. |
-| `sensor.meshtastic_last_message` | Payload of the last received text along with sender and gateway attributes. |
+| `sensor.meshtastic_snr` | Current SNR reported by the node. |
+| `sensor.meshtastic_last_message` | Text of the last received message plus sender, gateway, message type, and timestamp attributes. |
+| `sensor.meshtastic_battery` | Battery level reported by the node (percentage). |
+| `sensor.meshtastic_battery_voltage` | Battery voltage reported by the node. |
+| `sensor.meshtastic_temperature` | Device temperature reported by the node. |
+| `sensor.meshtastic_uptime` | Node uptime in seconds. |
 
-Each sensor also publishes extended attributes such as hardware model, region, role, BLE information, airtime utilisation, and mesh route table size.
+All sensors include extensive attributes such as hardware model, region, role, BLE information, airtime utilisation, route table size, and the raw connection details.
+
+## Home Assistant services
+
+| Service | Description |
+| --- | --- |
+| `meshtastic_usb.send_message` | Send a text message through the selected Meshtastic node (optionally target a specific node ID). |
+| `meshtastic_usb.reboot` | Reboot the node. |
+| `meshtastic_usb.set_channel` | Change the primary channel by name. |
+| `meshtastic_usb.refresh` | Request an immediate data refresh from the node. |
+
+All services accept an optional `entry_id` when multiple nodes are configured; otherwise the single configured node is used.
 
 ## Installation (Home Assistant OS via HACS)
 
 1. Install [HACS](https://hacs.xyz/) if it is not already available in your Home Assistant instance.
 2. In Home Assistant, open **HACS → Integrations → ⋮ (three dots) → Custom repositories**.
 3. Enter `https://github.com/Skrap87/MeshtasticHA` as the repository URL, choose **Integration** as the category, and click **Add**.
-4. The repository now appears in HACS. Click **Download** on the Meshtastic USB card and restart Home Assistant when prompted. The integration bundles the Meshtastic Python API directly from the official GitHub repository (tag `2.2.27`) so HACS will fetch the dependency automatically.
-5. After Home Assistant restarts, go to **Settings → Devices & Services → + Add Integration**, search for **Meshtastic USB**, and complete the setup wizard.
+4. The repository now appears in HACS. Click **Download** on the Meshtastic card and restart Home Assistant when prompted. The integration bundles the Meshtastic Python API directly from the official GitHub repository so HACS will fetch the dependency automatically.
+5. After Home Assistant restarts, go to **Settings → Devices & Services → + Add Integration**, search for **Meshtastic**, and complete the setup wizard. Choose USB serial or TCP connectivity per node and (optionally) run network discovery for TCP radios.
 
 ## Manual installation
 
 1. Copy the `custom_components/meshtastic_usb` folder into the `custom_components` directory of your Home Assistant configuration. If the directory does not exist, create it.
 2. Restart Home Assistant. The integration will download the Meshtastic Python API from the official GitHub repository (tag `2.2.27`) on first start so outbound internet access is required for the initial setup.
 3. In Home Assistant, navigate to **Settings → Devices & Services → Integrations** and click **Add Integration**.
-4. Search for **Meshtastic USB** and complete the setup wizard.
+4. Search for **Meshtastic** and complete the setup wizard.
 
 ## USB passthrough tips
 
@@ -47,7 +64,7 @@ The integration communicates directly with the USB serial device. When running H
 1. Shut down the Home Assistant OS VM.
 2. In VirtualBox Manager open the VM **Settings → Ports → USB** panel.
 3. Enable the USB controller that matches your adapter (USB 2.0 for most radios) and add a USB device filter for the adapter. The VID/PID list below can help you identify the correct device.
-4. Start the VM, open Home Assistant, and re-run the Meshtastic USB config flow.
+4. Start the VM, open Home Assistant, and re-run the Meshtastic config flow.
 
 ### Proxmox VE
 

--- a/custom_components/meshtastic_usb/__init__.py
+++ b/custom_components/meshtastic_usb/__init__.py
@@ -1,38 +1,94 @@
-"""The Meshtastic USB integration."""
+"""Meshtastic integration setup and services."""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
+from typing import Any, Mapping
+
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import config_validation as cv
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS
+from .connection import (
+    MeshtasticConnectionError,
+    reboot_node,
+    send_text_message,
+    set_primary_channel,
+)
+from .const import (
+    ATTR_CHANNEL_NAME,
+    ATTR_ENTRY_ID,
+    ATTR_MESSAGE,
+    ATTR_TARGET,
+    DOMAIN,
+    PLATFORMS,
+    SERVICE_REFRESH,
+    SERVICE_REBOOT,
+    SERVICE_SEND_MESSAGE,
+    SERVICE_SET_CHANNEL,
+)
 from .coordinator import MeshtasticUsbCoordinator
 from .version import __version__
 
 _LOGGER = logging.getLogger(__name__)
 
+DATA_COORDINATORS = "coordinators"
+DATA_SERVICES_REGISTERED = "services_registered"
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up the Meshtastic USB component."""
-    hass.data.setdefault(DOMAIN, {})
-    _LOGGER.debug("Setting up Meshtastic USB integration version %s", __version__)
+SERVICE_SEND_MESSAGE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Optional(ATTR_TARGET): cv.string,
+        vol.Required(ATTR_MESSAGE): cv.string,
+    }
+)
+
+SERVICE_REBOOT_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTRY_ID): cv.string})
+
+SERVICE_SET_CHANNEL_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+        vol.Required(ATTR_CHANNEL_NAME): cv.string,
+    }
+)
+
+SERVICE_REFRESH_SCHEMA = vol.Schema({vol.Optional(ATTR_ENTRY_ID): cv.string})
+
+
+async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
+    """Set up the Meshtastic component."""
+    hass.data.setdefault(
+        DOMAIN,
+        {
+            DATA_COORDINATORS: {},
+            DATA_SERVICES_REGISTERED: False,
+        },
+    )
+    _LOGGER.debug("Setting up Meshtastic integration version %s", __version__)
+
+    if not hass.data[DOMAIN][DATA_SERVICES_REGISTERED]:
+        _async_register_services(hass)
+        hass.data[DOMAIN][DATA_SERVICES_REGISTERED] = True
+
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Meshtastic USB from a config entry."""
-    coordinator = MeshtasticUsbCoordinator(hass, DEFAULT_SCAN_INTERVAL)
+    """Set up Meshtastic from a config entry."""
+    coordinator = MeshtasticUsbCoordinator(hass, entry)
 
     try:
         await coordinator.async_config_entry_first_refresh()
-    except Exception as err:
+    except Exception as err:  # pragma: no cover - defensive startup guard
         raise ConfigEntryNotReady from err
 
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    hass.data[DOMAIN][DATA_COORDINATORS][entry.entry_id] = coordinator
 
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -41,5 +97,95 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN][DATA_COORDINATORS].pop(entry.entry_id, None)
     return unload_ok
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options updates by reloading the entry."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+def _async_register_services(hass: HomeAssistant) -> None:
+    """Register Meshtastic domain services."""
+
+    async def _async_call_with_connection(
+        call: ServiceCall,
+        executor,
+        *args,
+    ) -> None:
+        for coordinator in _resolve_coordinators(hass, call.data):
+            config = coordinator.connection_config
+            try:
+                await hass.async_add_executor_job(executor, config, *args)
+            except MeshtasticConnectionError as err:
+                raise HomeAssistantError(str(err)) from err
+
+    async def _async_handle_send_message(call: ServiceCall) -> None:
+        message: str = call.data[ATTR_MESSAGE]
+        target: str | None = call.data.get(ATTR_TARGET)
+        if not message.strip():
+            raise HomeAssistantError("Message cannot be empty")
+        await _async_call_with_connection(call, send_text_message, message, target)
+
+    async def _async_handle_reboot(call: ServiceCall) -> None:
+        await _async_call_with_connection(call, reboot_node)
+
+    async def _async_handle_set_channel(call: ServiceCall) -> None:
+        channel_name: str = call.data[ATTR_CHANNEL_NAME]
+        if not channel_name.strip():
+            raise HomeAssistantError("Channel name cannot be empty")
+        await _async_call_with_connection(call, set_primary_channel, channel_name)
+
+    async def _async_handle_refresh(call: ServiceCall) -> None:
+        for coordinator in _resolve_coordinators(hass, call.data):
+            await coordinator.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SEND_MESSAGE,
+        _async_handle_send_message,
+        schema=SERVICE_SEND_MESSAGE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REBOOT,
+        _async_handle_reboot,
+        schema=SERVICE_REBOOT_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_CHANNEL,
+        _async_handle_set_channel,
+        schema=SERVICE_SET_CHANNEL_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REFRESH,
+        _async_handle_refresh,
+        schema=SERVICE_REFRESH_SCHEMA,
+    )
+
+
+def _resolve_coordinators(
+    hass: HomeAssistant, data: Mapping[str, Any]
+) -> Iterable[MeshtasticUsbCoordinator]:
+    """Return the coordinators targeted by a service call."""
+    entry_id: str | None = data.get(ATTR_ENTRY_ID)
+    coordinators: dict[str, MeshtasticUsbCoordinator] = hass.data[DOMAIN][
+        DATA_COORDINATORS
+    ]
+
+    if entry_id:
+        coordinator = coordinators.get(entry_id)
+        if coordinator is None:
+            raise HomeAssistantError(f"Unknown Meshtastic entry_id: {entry_id}")
+        return [coordinator]
+
+    if len(coordinators) == 1:
+        return list(coordinators.values())
+
+    if not coordinators:
+        raise HomeAssistantError("No Meshtastic entries configured")
+
+    raise HomeAssistantError("Multiple Meshtastic entries configured; provide entry_id")

--- a/custom_components/meshtastic_usb/config_flow.py
+++ b/custom_components/meshtastic_usb/config_flow.py
@@ -1,25 +1,349 @@
-"""Config flow for the Meshtastic USB integration."""
+"""Config flow for the Meshtastic integration."""
 
 from __future__ import annotations
+
+from collections.abc import Mapping
+import logging
+from typing import Any
 
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.core import callback
 
-from .const import DOMAIN
+from .connection import (
+    DiscoveredTcpDevice,
+    MeshtasticConnectionConfig,
+    MeshtasticConnectionError,
+    MeshtasticDevice,
+    discover_tcp_devices,
+    list_serial_ports,
+    read_meshtastic_device,
+)
+from .const import (
+    AUTODETECT_SERIAL,
+    CONF_CONNECTION_TYPE,
+    CONF_SERIAL_PORT,
+    CONF_TCP_HOST,
+    CONF_TCP_PORT,
+    CONF_UPDATE_INTERVAL,
+    CONNECTION_TYPE_SERIAL,
+    CONNECTION_TYPE_TCP,
+    DEFAULT_TCP_PORT,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class MeshtasticUsbConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Meshtastic USB."""
+    """Handle a config flow for Meshtastic."""
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
-        """Handle the initial step."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
+    def __init__(self) -> None:
+        self._connection_type: str | None = None
+        self._discovered_devices: dict[str, DiscoveredTcpDevice] = {}
 
+    async def async_step_user(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Handle the initial step where the connection type is selected."""
         if user_input is None:
-            return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_CONNECTION_TYPE): vol.In(
+                            {
+                                CONNECTION_TYPE_SERIAL: "serial",
+                                CONNECTION_TYPE_TCP: "tcp",
+                            }
+                        )
+                    }
+                ),
+            )
 
-        return self.async_create_entry(title="Meshtastic USB", data={})
+        self._connection_type = user_input[CONF_CONNECTION_TYPE]
+        if self._connection_type == CONNECTION_TYPE_SERIAL:
+            return await self.async_step_serial()
+        if self._connection_type == CONNECTION_TYPE_TCP:
+            return await self.async_step_tcp()
+        return self.async_abort(reason="invalid_connection")
+
+    async def async_step_serial(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Handle configuration for serial connections."""
+        assert self._connection_type == CONNECTION_TYPE_SERIAL
+
+        errors: dict[str, str] = {}
+        try:
+            ports = await self.hass.async_add_executor_job(list_serial_ports)
+        except MeshtasticConnectionError as err:
+            _LOGGER.error("Unable to list Meshtastic serial ports: %s", err)
+            ports = []
+            errors["base"] = self._map_error(str(err))
+
+        options: dict[str, str] = {AUTODETECT_SERIAL: "autodetect"}
+        for port in ports:
+            label = port.device
+            if port.description:
+                label = f"{port.device} ({port.description})"
+            options[port.device] = label
+
+        if user_input is not None:
+            selected_port = user_input[CONF_SERIAL_PORT]
+            update_interval = user_input[CONF_UPDATE_INTERVAL]
+            if self._is_duplicate_serial(selected_port):
+                return self.async_abort(reason="already_configured")
+
+            config = MeshtasticConnectionConfig(
+                connection_type=CONNECTION_TYPE_SERIAL,
+                serial_port=selected_port,
+            )
+            device, error_key = await self._async_try_connect(config)
+            if error_key is None and device is not None:
+                return await self._async_create_entry(device, config, update_interval)
+            errors["base"] = error_key or "cannot_connect"
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_SERIAL_PORT, default=AUTODETECT_SERIAL): vol.In(options),
+                vol.Required(
+                    CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
+            }
+        )
+        return self.async_show_form(step_id="serial", data_schema=schema, errors=errors)
+
+    async def async_step_tcp(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Show menu for TCP configuration options."""
+        return self.async_show_menu(
+            step_id="tcp",
+            menu_options={
+                "tcp_manual": "manual",
+                "tcp_discovery": "discovery",
+            },
+        )
+
+    async def async_step_tcp_manual(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Handle manual TCP configuration."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input[CONF_TCP_HOST]
+            port = user_input.get(CONF_TCP_PORT, DEFAULT_TCP_PORT)
+            update_interval = user_input[CONF_UPDATE_INTERVAL]
+
+            if self._is_duplicate_tcp(host, port):
+                return self.async_abort(reason="already_configured")
+
+            config = MeshtasticConnectionConfig(
+                connection_type=CONNECTION_TYPE_TCP,
+                tcp_host=host,
+                tcp_port=port,
+            )
+            device, error_key = await self._async_try_connect(config)
+            if error_key is None and device is not None:
+                return await self._async_create_entry(device, config, update_interval)
+            errors["base"] = error_key or "cannot_connect"
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_TCP_HOST): str,
+                vol.Required(CONF_TCP_PORT, default=DEFAULT_TCP_PORT): vol.All(
+                    vol.Coerce(int), vol.Range(min=1, max=65535)
+                ),
+                vol.Required(
+                    CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
+            }
+        )
+        return self.async_show_form(step_id="tcp_manual", data_schema=schema, errors=errors)
+
+    async def async_step_tcp_discovery(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Handle discovery of TCP devices."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            selection = user_input.get("device")
+            update_interval = user_input[CONF_UPDATE_INTERVAL]
+            if not selection or selection not in self._discovered_devices:
+                errors["base"] = "device_not_found"
+            else:
+                discovered = self._discovered_devices[selection]
+                if self._is_duplicate_tcp(discovered.host, discovered.port):
+                    return self.async_abort(reason="already_configured")
+                config = MeshtasticConnectionConfig(
+                    connection_type=CONNECTION_TYPE_TCP,
+                    tcp_host=discovered.host,
+                    tcp_port=discovered.port,
+                )
+                device, error_key = await self._async_try_connect(config)
+                if error_key is None and device is not None:
+                    return await self._async_create_entry(device, config, update_interval)
+                errors["base"] = error_key or "cannot_connect"
+
+        if not errors:
+            await self._async_run_discovery()
+            if not self._discovered_devices:
+                errors["base"] = "no_devices_found"
+
+        options = {
+            key: device.title for key, device in self._discovered_devices.items()
+        }
+        schema = vol.Schema(
+            {
+                vol.Required("device"): vol.In(options) if options else str,
+                vol.Required(
+                    CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
+            }
+        )
+        return self.async_show_form(
+            step_id="tcp_discovery", data_schema=schema, errors=errors
+        )
+
+    async def _async_run_discovery(self) -> None:
+        """Populate the discovered TCP devices cache."""
+        try:
+            devices = await self.hass.async_add_executor_job(discover_tcp_devices)
+        except MeshtasticConnectionError as err:
+            _LOGGER.error("Meshtastic TCP discovery failed: %s", err)
+            self._discovered_devices = {}
+            return
+        except Exception as err:  # pragma: no cover - defensive logging
+            _LOGGER.exception("Unexpected error during Meshtastic discovery")
+            self._discovered_devices = {}
+            return
+
+        self._discovered_devices = {
+            f"{device.host}:{device.port}": device for device in devices
+        }
+
+    async def _async_try_connect(
+        self, config: MeshtasticConnectionConfig
+    ) -> tuple[MeshtasticDevice | None, str | None]:
+        """Attempt to connect to a Meshtastic device."""
+        try:
+            device = await self.hass.async_add_executor_job(read_meshtastic_device, config)
+            return device, None
+        except MeshtasticConnectionError as err:
+            return None, self._map_error(str(err))
+        except Exception as err:  # pragma: no cover - defensive logging
+            _LOGGER.exception("Unexpected error during Meshtastic connection test")
+            return None, "cannot_connect"
+
+    async def _async_create_entry(
+        self,
+        device: MeshtasticDevice,
+        config: MeshtasticConnectionConfig,
+        update_interval: int,
+    ) -> config_entries.FlowResult:
+        """Create the config entry with populated data."""
+
+        unique_id = self._derive_unique_id(device, config)
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        data: dict[str, Any] = {
+            CONF_CONNECTION_TYPE: config.connection_type,
+            CONF_UPDATE_INTERVAL: update_interval,
+        }
+        if config.connection_type == CONNECTION_TYPE_SERIAL:
+            data[CONF_SERIAL_PORT] = config.serial_port or AUTODETECT_SERIAL
+        else:
+            data[CONF_TCP_HOST] = config.tcp_host
+            data[CONF_TCP_PORT] = config.tcp_port or DEFAULT_TCP_PORT
+
+        title = device.display_name if getattr(device, "display_name", None) else None
+        if not title:
+            if config.connection_type == CONNECTION_TYPE_SERIAL:
+                title = "Meshtastic Serial"
+            else:
+                title = f"Meshtastic {config.tcp_host}:{config.tcp_port}"
+
+        return self.async_create_entry(title=title, data=data)
+
+    def _is_duplicate_serial(self, serial_port: str) -> bool:
+        """Return True if a serial configuration already exists."""
+        for entry in self._async_current_entries():
+            if entry.data.get(CONF_CONNECTION_TYPE) != CONNECTION_TYPE_SERIAL:
+                continue
+            existing_port = entry.data.get(CONF_SERIAL_PORT, AUTODETECT_SERIAL)
+            if existing_port == serial_port:
+                return True
+        return False
+
+    def _is_duplicate_tcp(self, host: str, port: int) -> bool:
+        """Return True if a TCP configuration already exists."""
+        for entry in self._async_current_entries():
+            if entry.data.get(CONF_CONNECTION_TYPE) != CONNECTION_TYPE_TCP:
+                continue
+            existing_host = entry.data.get(CONF_TCP_HOST)
+            existing_port = int(entry.data.get(CONF_TCP_PORT, DEFAULT_TCP_PORT))
+            if existing_host == host and existing_port == port:
+                return True
+        return False
+
+    def _map_error(self, error: str) -> str:
+        """Map connection errors to translation keys."""
+        mapping = {
+            "serial_port_not_found": "serial_port_not_found",
+            "tcp_host_missing": "tcp_host_missing",
+            "meshtastic_library_missing": "library_missing",
+            "pyserial_not_available": "serial_library_missing",
+        }
+        return mapping.get(error, "cannot_connect")
+
+    def _derive_unique_id(self, device, config: MeshtasticConnectionConfig) -> str:
+        """Return the unique identifier for the config entry."""
+        node = getattr(device, "node", None)
+        if node and node.my_node_id:
+            return node.my_node_id.lower()
+        if config.connection_type == CONNECTION_TYPE_SERIAL:
+            serial_port = getattr(device, "serial_port", None) or config.serial_port or AUTODETECT_SERIAL
+            return f"serial:{serial_port}"
+        tcp_host = config.tcp_host or "unknown"
+        tcp_port = config.tcp_port or DEFAULT_TCP_PORT
+        return f"tcp:{tcp_host}:{tcp_port}"
+
+    @callback
+    def async_get_options_flow(self, config_entry: config_entries.ConfigEntry):
+        """Return the options flow handler."""
+        return MeshtasticUsbOptionsFlow(config_entry)
+
+
+class MeshtasticUsbOptionsFlow(config_entries.OptionsFlow):
+    """Handle options for existing Meshtastic entries."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: Mapping[str, Any] | None = None
+    ) -> config_entries.FlowResult:
+        """Manage options for the integration."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current_interval = self.config_entry.options.get(
+            CONF_UPDATE_INTERVAL,
+            self.config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        )
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_UPDATE_INTERVAL, default=current_interval
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600))
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/meshtastic_usb/connection.py
+++ b/custom_components/meshtastic_usb/connection.py
@@ -1,0 +1,553 @@
+"""Helpers for working with Meshtastic connections."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import ipaddress
+import logging
+import socket
+from contextlib import closing, suppress
+from typing import Any, Iterable
+
+from .const import (
+    AUTODETECT_SERIAL,
+    CONNECTION_TYPE_SERIAL,
+    CONNECTION_TYPE_TCP,
+    DEFAULT_TCP_PORT,
+    IGNORED_PORT_PREFIXES,
+    MESHTASTIC_VID_PID,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MeshtasticConnectionError(Exception):
+    """Raised when a Meshtastic connection could not be established."""
+
+
+@dataclass
+class UsbDevice:
+    """Representation of a USB serial device."""
+
+    device: str
+    description: str | None = None
+    hwid: str | None = None
+    manufacturer: str | None = None
+    product: str | None = None
+    serial_number: str | None = None
+    vid: int | None = None
+    pid: int | None = None
+    location: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dictionary with serializable values."""
+        data = asdict(self)
+        if self.vid is not None:
+            data["vid"] = f"0x{self.vid:04x}"
+        if self.pid is not None:
+            data["pid"] = f"0x{self.pid:04x}"
+        return {key: value for key, value in data.items() if value is not None}
+
+
+@dataclass
+class MeshtasticNodeDetails:
+    """Details retrieved from a Meshtastic node."""
+
+    firmware: str | None = None
+    node_num: int | None = None
+    hw_model: str | None = None
+    my_node_id: str | None = None
+    node_name: str | None = None
+    region: str | None = None
+    role: str | None = None
+    route_table_size: int | None = None
+    channel: str | None = None
+    channels: list[str] = field(default_factory=list)
+    ble_mac: str | None = None
+    ble_name: str | None = None
+    rssi: float | None = None
+    snr: float | None = None
+    airtime_utilization: float | None = None
+    last_message: str | None = None
+    last_sender: str | None = None
+    last_gateway: str | None = None
+    last_message_type: str | None = None
+    last_message_time: int | None = None
+    battery_level: float | None = None
+    battery_voltage: float | None = None
+    temperature: float | None = None
+    uptime: int | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the node details."""
+        data = asdict(self)
+        return {key: value for key, value in data.items() if value not in (None, [], "")}
+
+
+@dataclass
+class MeshtasticDevice:
+    """Representation of a Meshtastic device connection."""
+
+    connection_type: str
+    serial_port: str | None = None
+    tcp_host: str | None = None
+    tcp_port: int | None = None
+    usb: UsbDevice | None = None
+    node: MeshtasticNodeDetails | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a serializable representation."""
+        data: dict[str, Any] = {"connection_type": self.connection_type}
+        if self.serial_port:
+            data["serial_port"] = self.serial_port
+        if self.tcp_host:
+            data["tcp_host"] = self.tcp_host
+        if self.tcp_port:
+            data["tcp_port"] = self.tcp_port
+        if self.usb:
+            data["usb"] = self.usb.as_dict()
+        if self.node:
+            data["node"] = self.node.as_dict()
+        if self.error:
+            data["error"] = self.error
+        return data
+
+    @property
+    def identifier(self) -> str:
+        """Return an identifier suitable for the device registry."""
+        if self.node and self.node.my_node_id:
+            return self.node.my_node_id.lower()
+        if self.connection_type == CONNECTION_TYPE_SERIAL and self.serial_port:
+            return f"serial:{self.serial_port}"
+        if self.connection_type == CONNECTION_TYPE_TCP and self.tcp_host:
+            port = self.tcp_port or DEFAULT_TCP_PORT
+            return f"tcp:{self.tcp_host}:{port}"
+        return "unknown"
+
+    @property
+    def display_name(self) -> str:
+        """Return a human readable name for the device."""
+        node = self.node
+        name = node.node_name if node and node.node_name else None
+        node_id = node.my_node_id if node and node.my_node_id else None
+        if name and node_id:
+            return f"{name} ({node_id})"
+        if name:
+            return name
+        if node_id:
+            return node_id
+        if self.connection_type == CONNECTION_TYPE_SERIAL and self.serial_port:
+            return f"Serial {self.serial_port}"
+        if self.connection_type == CONNECTION_TYPE_TCP and self.tcp_host:
+            port = self.tcp_port or DEFAULT_TCP_PORT
+            return f"TCP {self.tcp_host}:{port}"
+        return "Meshtastic"
+
+
+@dataclass
+class MeshtasticConnectionConfig:
+    """Configuration used to establish a Meshtastic connection."""
+
+    connection_type: str
+    serial_port: str | None = None
+    tcp_host: str | None = None
+    tcp_port: int | None = None
+
+
+@dataclass
+class DiscoveredTcpDevice:
+    """Representation of a discovered Meshtastic TCP device."""
+
+    host: str
+    port: int
+    node: MeshtasticNodeDetails | None
+
+    @property
+    def title(self) -> str:
+        """Return a friendly title for config flow selection."""
+        node = self.node
+        if node and (node.node_name or node.my_node_id):
+            name = node.node_name or node.my_node_id
+            return f"{name} ({self.host}:{self.port})"
+        return f"{self.host}:{self.port}"
+
+
+def list_serial_ports() -> list[UsbDevice]:
+    """Return a list of available Meshtastic serial ports."""
+    try:
+        from serial.tools import list_ports
+    except ImportError as err:  # pragma: no cover - provided by Home Assistant
+        raise MeshtasticConnectionError("pyserial_not_available") from err
+
+    ports: list[UsbDevice] = []
+    for port in list_ports.comports():
+        if _should_ignore_port(port.device, port.description):
+            continue
+        if port.vid is None or port.pid is None:
+            continue
+        if (port.vid, port.pid) not in MESHTASTIC_VID_PID:
+            continue
+        ports.append(
+            UsbDevice(
+                device=port.device,
+                description=port.description,
+                hwid=port.hwid,
+                manufacturer=getattr(port, "manufacturer", None),
+                product=getattr(port, "product", None),
+                serial_number=getattr(port, "serial_number", None),
+                vid=getattr(port, "vid", None),
+                pid=getattr(port, "pid", None),
+                location=getattr(port, "location", None),
+            )
+        )
+    return ports
+
+
+def find_serial_device(serial_port: str | None) -> UsbDevice | None:
+    """Return the matching USB device for the provided port."""
+    desired = None if serial_port in (None, AUTODETECT_SERIAL) else serial_port
+    ports = list_serial_ports()
+    if desired is None:
+        return ports[0] if ports else None
+    for port in ports:
+        if port.device == desired:
+            return port
+    return None
+
+
+def read_meshtastic_device(config: MeshtasticConnectionConfig) -> MeshtasticDevice:
+    """Read details for a Meshtastic device described by the config."""
+    usb_device: UsbDevice | None = None
+    resolved_serial: str | None = None
+    tcp_host: str | None = None
+    tcp_port: int | None = None
+
+    if config.connection_type == CONNECTION_TYPE_SERIAL:
+        usb_device = find_serial_device(config.serial_port)
+        if usb_device is None:
+            raise MeshtasticConnectionError("serial_port_not_found")
+        interface = _create_serial_interface(usb_device.device)
+        resolved_serial = usb_device.device
+    elif config.connection_type == CONNECTION_TYPE_TCP:
+        if not config.tcp_host:
+            raise MeshtasticConnectionError("tcp_host_missing")
+        port = config.tcp_port or DEFAULT_TCP_PORT
+        interface = _create_tcp_interface(config.tcp_host, port)
+        tcp_host = config.tcp_host
+        tcp_port = port
+    else:
+        raise MeshtasticConnectionError("invalid_connection_type")
+
+    try:
+        node_details = _read_node_details(interface)
+    finally:
+        with suppress(Exception):
+            interface.close()
+
+    device = MeshtasticDevice(
+        connection_type=config.connection_type,
+        serial_port=resolved_serial,
+        tcp_host=tcp_host,
+        tcp_port=tcp_port,
+        usb=usb_device,
+        node=node_details,
+    )
+    return device
+
+
+def send_text_message(config: MeshtasticConnectionConfig, message: str, target: str | None) -> None:
+    """Send a text message using the provided configuration."""
+    interface, _device = _open_interface_from_config(config)
+    try:
+        if not hasattr(interface, "sendText"):
+            raise MeshtasticConnectionError("send_text_not_supported")
+        kwargs: dict[str, Any] = {}
+        if target:
+            kwargs["destinationId"] = target
+        interface.sendText(message, **kwargs)
+    finally:
+        with suppress(Exception):
+            interface.close()
+
+
+def reboot_node(config: MeshtasticConnectionConfig) -> None:
+    """Reboot the node referenced by the configuration."""
+    interface, _device = _open_interface_from_config(config)
+    try:
+        if not hasattr(interface, "reboot"):
+            raise MeshtasticConnectionError("reboot_not_supported")
+        interface.reboot()
+    finally:
+        with suppress(Exception):
+            interface.close()
+
+
+def set_primary_channel(config: MeshtasticConnectionConfig, channel_name: str) -> None:
+    """Set the primary channel by name."""
+    interface, _device = _open_interface_from_config(config)
+    try:
+        if not hasattr(interface, "setPrimaryChannel"):
+            raise MeshtasticConnectionError("set_channel_not_supported")
+        interface.setPrimaryChannel(channel_name)
+    finally:
+        with suppress(Exception):
+            interface.close()
+
+
+def discover_tcp_devices(
+    port: int = DEFAULT_TCP_PORT,
+    timeout: float = 0.5,
+    subnet: str | None = None,
+) -> list[DiscoveredTcpDevice]:
+    """Discover Meshtastic nodes that expose a TCP interface."""
+    hosts = _iter_discovery_hosts(subnet)
+    discovered: list[DiscoveredTcpDevice] = []
+    for host in hosts:
+        if host in {"127.0.0.1", "0.0.0.0"}:
+            continue
+        if not _is_port_open(host, port, timeout):
+            continue
+        try:
+            device = read_meshtastic_device(
+                MeshtasticConnectionConfig(
+                    connection_type=CONNECTION_TYPE_TCP,
+                    tcp_host=host,
+                    tcp_port=port,
+                )
+            )
+        except MeshtasticConnectionError:
+            continue
+        except Exception as exc:  # pragma: no cover - defensive logging
+            _LOGGER.debug("Unexpected error while probing %s:%s: %s", host, port, exc)
+            continue
+        discovered.append(DiscoveredTcpDevice(host=host, port=port, node=device.node))
+    return discovered
+
+
+def _open_interface_from_config(config: MeshtasticConnectionConfig):
+    """Return an open interface and associated USB device for the config."""
+    if config.connection_type == CONNECTION_TYPE_SERIAL:
+        usb_device = find_serial_device(config.serial_port)
+        if usb_device is None:
+            raise MeshtasticConnectionError("serial_port_not_found")
+        return _create_serial_interface(usb_device.device), usb_device
+    if config.connection_type == CONNECTION_TYPE_TCP:
+        if not config.tcp_host:
+            raise MeshtasticConnectionError("tcp_host_missing")
+        port = config.tcp_port or DEFAULT_TCP_PORT
+        return _create_tcp_interface(config.tcp_host, port), None
+    raise MeshtasticConnectionError("invalid_connection_type")
+
+
+def _create_serial_interface(device_path: str):
+    try:
+        from meshtastic.serial_interface import SerialInterface
+    except ImportError as err:  # pragma: no cover - dependency provided by manifest
+        raise MeshtasticConnectionError("meshtastic_library_missing") from err
+
+    try:
+        return SerialInterface(device_path, noProto=False)
+    except Exception as err:  # pragma: no cover - serial errors originate here
+        raise MeshtasticConnectionError(str(err)) from err
+
+
+def _create_tcp_interface(host: str, port: int):
+    try:
+        from meshtastic.tcp_interface import TCPInterface
+    except ImportError as err:  # pragma: no cover - dependency provided by manifest
+        raise MeshtasticConnectionError("meshtastic_library_missing") from err
+
+    try:
+        return TCPInterface(host, port=port)
+    except Exception as err:  # pragma: no cover - tcp errors originate here
+        raise MeshtasticConnectionError(str(err)) from err
+
+
+def _read_node_details(interface) -> MeshtasticNodeDetails:
+    """Populate node details from an open interface."""
+    node_details = MeshtasticNodeDetails()
+
+    my_info = getattr(interface, "myInfo", None)
+    radio_config = getattr(interface, "radioConfig", None)
+    nodes = getattr(interface, "nodes", {}) or {}
+    channels = getattr(interface, "channels", []) or []
+    last_received = getattr(interface, "lastReceived", None)
+
+    my_info_dict = _protobuf_to_dict(my_info)
+    radio_config_dict = _protobuf_to_dict(radio_config)
+    last_received_dict = _protobuf_to_dict(last_received)
+
+    node_details.firmware = my_info_dict.get("firmware_version")
+    node_details.node_num = my_info_dict.get("my_node_num")
+    node_details.hw_model = my_info_dict.get("hw_model")
+    node_details.my_node_id = my_info_dict.get("my_node_id")
+
+    node_info = my_info_dict.get("node_info") or {}
+    user_info = node_info.get("user") or {}
+    node_details.node_name = user_info.get("long_name") or user_info.get("short_name")
+
+    node_details.region = my_info_dict.get("region") or (
+        (radio_config_dict.get("preferences") or {}).get("region")
+    )
+    node_details.role = (
+        (radio_config_dict.get("preferences") or {}).get("role")
+        or node_info.get("role")
+    )
+    node_details.route_table_size = len(nodes)
+
+    ble_info = my_info_dict.get("ble") or my_info_dict.get("ble_info") or {}
+    node_details.ble_mac = ble_info.get("macaddr") or ble_info.get("address") or ble_info.get("mac")
+    node_details.ble_name = ble_info.get("name") or ble_info.get("hostname")
+
+    node_details.channels = _extract_channel_names(channels)
+    if node_details.channels:
+        node_details.channel = node_details.channels[0]
+
+    metrics_dict = my_info_dict.get("node_metrics") or {}
+    node_details.rssi = (
+        metrics_dict.get("rssi")
+        or metrics_dict.get("rx_rssi")
+        or metrics_dict.get("last_heard_rssi")
+    )
+    node_details.snr = (
+        metrics_dict.get("snr")
+        or metrics_dict.get("rx_snr")
+        or metrics_dict.get("last_heard_snr")
+    )
+    node_details.airtime_utilization = (
+        metrics_dict.get("air_util_tx")
+        or metrics_dict.get("air_util")
+        or metrics_dict.get("airtime")
+    )
+
+    device_metrics = my_info_dict.get("device_metrics") or {}
+    node_details.battery_level = device_metrics.get("battery_level")
+    node_details.battery_voltage = device_metrics.get("voltage") or device_metrics.get("battery_voltage")
+    node_details.temperature = device_metrics.get("temperature")
+    node_details.uptime = my_info_dict.get("uptime") or device_metrics.get("uptime")
+
+    if (node_details.rssi is None or node_details.snr is None) and nodes:
+        my_node = nodes.get(node_details.node_num)
+        if my_node is not None:
+            node_dict = _protobuf_to_dict(my_node)
+            node_details.rssi = node_details.rssi or node_dict.get("rx_rssi")
+            node_details.snr = node_details.snr or node_dict.get("rx_snr")
+
+    decoded = last_received_dict.get("decoded") or {}
+    node_details.last_message = (
+        decoded.get("text")
+        or decoded.get("payload")
+        or decoded.get("data")
+    )
+    node_details.last_sender = last_received_dict.get("from") or last_received_dict.get("from_id")
+    node_details.last_gateway = last_received_dict.get("gateway_id") or last_received_dict.get("rx_gateway")
+    node_details.last_message_type = (
+        decoded.get("portnum")
+        or last_received_dict.get("portnum")
+        or last_received_dict.get("type")
+    )
+    node_details.last_message_time = (
+        last_received_dict.get("rx_time")
+        or last_received_dict.get("time")
+        or decoded.get("rx_time")
+    )
+
+    return node_details
+
+
+def _protobuf_to_dict(message: Any) -> dict[str, Any]:
+    """Convert a protobuf message into a dictionary."""
+    if message is None:
+        return {}
+
+    try:
+        from google.protobuf.json_format import MessageToDict
+    except ImportError:  # pragma: no cover - Home Assistant bundles protobuf
+        MessageToDict = None
+
+    if MessageToDict is not None:
+        try:
+            return MessageToDict(message, preserving_proto_field_name=True)
+        except Exception:  # pragma: no cover - fallback below
+            pass
+
+    try:
+        fields: dict[str, Any] = {}
+        for descriptor, value in message.ListFields():
+            if hasattr(value, "ListFields"):
+                fields[descriptor.name] = _protobuf_to_dict(value)
+            elif isinstance(value, Iterable) and not isinstance(value, (bytes, str)):
+                fields[descriptor.name] = [
+                    _protobuf_to_dict(item) if hasattr(item, "ListFields") else item
+                    for item in value
+                ]
+            else:
+                fields[descriptor.name] = value
+        return fields
+    except Exception:  # pragma: no cover - last resort fallback
+        return {}
+
+
+def _extract_channel_names(channels: list[Any]) -> list[str]:
+    """Return a list of channel names from protobuf channel definitions."""
+    channel_names: list[str] = []
+    for channel in channels:
+        channel_dict = _protobuf_to_dict(channel)
+        name = (
+            (channel_dict.get("settings") or {}).get("name")
+            or channel_dict.get("name")
+        )
+        if name:
+            channel_names.append(name)
+    return channel_names
+
+
+def _should_ignore_port(device: str, description: str | None) -> bool:
+    """Return True if the port should be ignored."""
+    for prefix in IGNORED_PORT_PREFIXES:
+        if device.startswith(prefix):
+            return True
+    if description and "virtualbox" in description.lower():
+        return True
+    return False
+
+
+def _iter_discovery_hosts(subnet: str | None) -> Iterable[str]:
+    """Yield candidate hosts for discovery."""
+    if subnet:
+        try:
+            network = ipaddress.ip_network(subnet, strict=False)
+        except ValueError:
+            _LOGGER.warning("Invalid subnet '%s' provided for discovery", subnet)
+            return []
+        return (str(host) for host in network.hosts())
+
+    local_ip = _get_local_ip()
+    try:
+        network = ipaddress.ip_network(f"{local_ip}/24", strict=False)
+    except ValueError:
+        return []
+    return (str(host) for host in network.hosts())
+
+
+def _get_local_ip() -> str:
+    """Return the best-effort local IP address for the host."""
+    with suppress(Exception):
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
+            with suppress(Exception):
+                sock.connect(("8.8.8.8", 80))
+                return sock.getsockname()[0]
+    with suppress(Exception):
+        return socket.gethostbyname(socket.gethostname())
+    return "127.0.0.1"
+
+
+def _is_port_open(host: str, port: int, timeout: float) -> bool:
+    """Check if the given TCP port is open."""
+    try:
+        with closing(socket.create_connection((host, port), timeout=timeout)):
+            return True
+    except OSError:
+        return False
+

--- a/custom_components/meshtastic_usb/const.py
+++ b/custom_components/meshtastic_usb/const.py
@@ -1,15 +1,33 @@
-"""Constants for the Meshtastic USB integration."""
+"""Constants for the Meshtastic integration."""
 
 from datetime import timedelta
+
 from homeassistant.const import Platform
 
 DOMAIN = "meshtastic_usb"
 PLATFORMS: list[Platform] = [Platform.SENSOR]
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
+
+CONF_CONNECTION_TYPE = "connection_type"
+CONNECTION_TYPE_SERIAL = "serial"
+CONNECTION_TYPE_TCP = "tcp"
+
+CONF_SERIAL_PORT = "serial_port"
+AUTODETECT_SERIAL = "auto"
+
+CONF_TCP_HOST = "tcp_host"
+CONF_TCP_PORT = "tcp_port"
+
+CONF_UPDATE_INTERVAL = "update_interval"
+DEFAULT_UPDATE_INTERVAL = 30  # seconds
+
+DEFAULT_TCP_PORT = 4403
+
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=DEFAULT_UPDATE_INTERVAL)
 
 ATTR_DEVICES = "devices"
 ATTR_NODE = "node"
 ATTR_USB = "usb"
+ATTR_TCP = "tcp"
 ATTR_ERROR = "error"
 
 SENSOR_FIRMWARE = "firmware"
@@ -18,6 +36,20 @@ SENSOR_CHANNEL = "channel"
 SENSOR_RSSI = "rssi"
 SENSOR_SNR = "snr"
 SENSOR_LAST_MESSAGE = "last_message"
+SENSOR_BATTERY_LEVEL = "battery_level"
+SENSOR_BATTERY_VOLTAGE = "battery_voltage"
+SENSOR_TEMPERATURE = "temperature"
+SENSOR_UPTIME = "uptime"
+
+SERVICE_SEND_MESSAGE = "send_message"
+SERVICE_REBOOT = "reboot"
+SERVICE_SET_CHANNEL = "set_channel"
+SERVICE_REFRESH = "refresh"
+
+ATTR_TARGET = "target"
+ATTR_MESSAGE = "message"
+ATTR_CHANNEL_NAME = "channel_name"
+ATTR_ENTRY_ID = "entry_id"
 
 # Known Meshtastic-compatible USB VID/PID pairs
 MESHTASTIC_VID_PID: set[tuple[int, int]] = {

--- a/custom_components/meshtastic_usb/coordinator.py
+++ b/custom_components/meshtastic_usb/coordinator.py
@@ -1,287 +1,103 @@
-"""Data update coordinator for the Meshtastic USB integration."""
+"""Data update coordinator for the Meshtastic integration."""
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import Any
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .connection import (
+    MeshtasticConnectionConfig,
+    MeshtasticConnectionError,
+    MeshtasticDevice,
+    read_meshtastic_device,
+)
 from .const import (
-    ATTR_ERROR,
-    ATTR_NODE,
-    ATTR_USB,
+    AUTODETECT_SERIAL,
+    CONF_CONNECTION_TYPE,
+    CONF_SERIAL_PORT,
+    CONF_TCP_HOST,
+    CONF_TCP_PORT,
+    CONF_UPDATE_INTERVAL,
+    CONNECTION_TYPE_SERIAL,
+    DEFAULT_TCP_PORT,
+    DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
-    IGNORED_PORT_PREFIXES,
-    MESHTASTIC_VID_PID,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class UsbDevice:
-    """Representation of a USB serial device."""
+class CoordinatorDeviceState:
+    """State returned by the coordinator."""
 
-    device: str
-    description: str | None
-    hwid: str | None
-    manufacturer: str | None
-    product: str | None
-    serial_number: str | None
-    vid: int | None
-    pid: int | None
-    location: str | None
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return a dictionary with serializable values."""
-        data = asdict(self)
-        if self.vid is not None:
-            data["vid"] = f"0x{self.vid:04x}"
-        if self.pid is not None:
-            data["pid"] = f"0x{self.pid:04x}"
-        return {key: value for key, value in data.items() if value is not None}
+    devices: list[MeshtasticDevice]
 
 
-@dataclass
-class MeshtasticNodeDetails:
-    """Details retrieved from a Meshtastic node."""
+class MeshtasticUsbCoordinator(DataUpdateCoordinator[CoordinatorDeviceState]):
+    """Coordinator that manages a Meshtastic connection."""
 
-    firmware: str | None = None
-    node_num: int | None = None
-    hw_model: str | None = None
-    my_node_id: str | None = None
-    node_name: str | None = None
-    region: str | None = None
-    role: str | None = None
-    route_table_size: int | None = None
-    channel: str | None = None
-    channels: list[str] = field(default_factory=list)
-    ble_mac: str | None = None
-    ble_name: str | None = None
-    rssi: float | None = None
-    snr: float | None = None
-    airtime_utilization: float | None = None
-    last_message: str | None = None
-    last_sender: str | None = None
-    last_gateway: str | None = None
-
-    def as_dict(self) -> dict[str, Any]:
-        """Serialize the node details."""
-        data = asdict(self)
-        return {key: value for key, value in data.items() if value not in (None, [], "")}
-
-
-@dataclass
-class MeshtasticDevice:
-    """A Meshtastic-capable USB device and its node details."""
-
-    usb: UsbDevice
-    node: MeshtasticNodeDetails | None = None
-    error: str | None = None
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return a serializable representation."""
-        data: dict[str, Any] = {ATTR_USB: self.usb.as_dict()}
-        if self.node:
-            data[ATTR_NODE] = self.node.as_dict()
-        if self.error:
-            data[ATTR_ERROR] = self.error
-        return data
-
-
-class MeshtasticUsbCoordinator(DataUpdateCoordinator[list[MeshtasticDevice]]):
-    """Coordinator that queries connected Meshtastic USB devices."""
-
-    def __init__(self, hass: HomeAssistant, update_interval: timedelta) -> None:
-        """Initialize the coordinator."""
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self.entry = entry
+        interval_seconds = entry.options.get(
+            CONF_UPDATE_INTERVAL,
+            entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        )
+        update_interval = timedelta(seconds=interval_seconds)
         super().__init__(
             hass,
             _LOGGER,
-            name=f"{DOMAIN} device scanner",
+            name=f"{DOMAIN} coordinator {entry.entry_id}",
             update_interval=update_interval,
         )
 
-    async def _async_update_data(self) -> list[MeshtasticDevice]:
-        """Fetch the latest list of connected Meshtastic USB devices."""
-        return await self.hass.async_add_executor_job(_scan_meshtastic_devices)
-
-
-def _scan_meshtastic_devices() -> list[MeshtasticDevice]:
-    """Return the connected Meshtastic USB devices."""
-    from serial.tools.list_ports import comports
-
-    devices: list[MeshtasticDevice] = []
-    for port in comports():
-        if _should_ignore_port(port.device, port.description):
-            continue
-        if port.vid is None or port.pid is None:
-            continue
-        if (port.vid, port.pid) not in MESHTASTIC_VID_PID:
-            continue
-
-        usb_device = UsbDevice(
-            device=port.device,
-            description=port.description,
-            hwid=port.hwid,
-            manufacturer=getattr(port, "manufacturer", None),
-            product=getattr(port, "product", None),
-            serial_number=getattr(port, "serial_number", None),
-            vid=getattr(port, "vid", None),
-            pid=getattr(port, "pid", None),
-            location=getattr(port, "location", None),
+    @property
+    def connection_config(self) -> MeshtasticConnectionConfig:
+        """Return the connection configuration for this coordinator."""
+        data = self.entry.data
+        connection_type: str = data.get(CONF_CONNECTION_TYPE, CONNECTION_TYPE_SERIAL)
+        serial_port = data.get(CONF_SERIAL_PORT, AUTODETECT_SERIAL)
+        tcp_host = data.get(CONF_TCP_HOST)
+        tcp_port = data.get(CONF_TCP_PORT, DEFAULT_TCP_PORT)
+        return MeshtasticConnectionConfig(
+            connection_type=connection_type,
+            serial_port=serial_port,
+            tcp_host=tcp_host,
+            tcp_port=tcp_port,
         )
 
-        device_entry = MeshtasticDevice(usb=usb_device)
-        try:
-            device_entry.node = _read_meshtastic_details(port.device)
-        except Exception as err:  # pylint: disable=broad-except
-            device_entry.error = str(err)
-            _LOGGER.error("Failed to read Meshtastic node on %s: %s", port.device, err)
-        devices.append(device_entry)
-    return devices
+    async def _async_update_data(self) -> CoordinatorDeviceState:
+        """Fetch the latest device data."""
+        config = self.connection_config
+        device = await self.hass.async_add_executor_job(_read_device_safe, config)
+        return CoordinatorDeviceState(devices=[device])
 
 
-def _should_ignore_port(device: str, description: str | None) -> bool:
-    """Return True if the port should be ignored."""
-    for prefix in IGNORED_PORT_PREFIXES:
-        if device.startswith(prefix):
-            return True
-    if description and "virtualbox" in description.lower():
-        return True
-    return False
-
-
-def _protobuf_to_dict(message: Any) -> dict[str, Any]:
-    """Convert a protobuf message into a dictionary."""
-    if message is None:
-        return {}
-
+def _read_device_safe(config: MeshtasticConnectionConfig) -> MeshtasticDevice:
+    """Read device data with error handling suitable for the coordinator."""
     try:
-        from google.protobuf.json_format import MessageToDict
-    except ImportError:  # pragma: no cover - Home Assistant bundles protobuf
-        MessageToDict = None
-
-    if MessageToDict is not None:
-        try:
-            return MessageToDict(message, preserving_proto_field_name=True)
-        except Exception:  # pragma: no cover - fallback below
-            pass
-
-    try:
-        fields: dict[str, Any] = {}
-        for descriptor, value in message.ListFields():
-            if hasattr(value, "ListFields"):
-                fields[descriptor.name] = _protobuf_to_dict(value)
-            elif isinstance(value, list):
-                fields[descriptor.name] = [
-                    _protobuf_to_dict(item) if hasattr(item, "ListFields") else item
-                    for item in value
-                ]
-            else:
-                fields[descriptor.name] = value
-        return fields
-    except Exception:  # pragma: no cover - last resort fallback
-        return {}
-
-
-def _read_meshtastic_details(device_path: str) -> MeshtasticNodeDetails:
-    """Return node details for a Meshtastic radio connected to the given path."""
-    from meshtastic.serial_interface import SerialInterface
-
-    interface = SerialInterface(device_path, noProto=False)
-    try:
-        node_details = MeshtasticNodeDetails()
-        my_info = getattr(interface, "myInfo", None)
-        radio_config = getattr(interface, "radioConfig", None)
-        nodes = getattr(interface, "nodes", {}) or {}
-        channels = getattr(interface, "channels", []) or []
-        last_received = getattr(interface, "lastReceived", None)
-
-        my_info_dict = _protobuf_to_dict(my_info)
-        radio_config_dict = _protobuf_to_dict(radio_config)
-        last_received_dict = _protobuf_to_dict(last_received)
-
-        node_details.firmware = my_info_dict.get("firmware_version")
-        node_details.node_num = my_info_dict.get("my_node_num")
-        node_details.hw_model = my_info_dict.get("hw_model")
-        node_details.my_node_id = my_info_dict.get("my_node_id")
-
-        node_info = my_info_dict.get("node_info") or {}
-        user_info = node_info.get("user") or {}
-        node_details.node_name = user_info.get("long_name") or user_info.get("short_name")
-
-        node_details.region = my_info_dict.get("region") or (
-            (radio_config_dict.get("preferences") or {}).get("region")
+        return read_meshtastic_device(config)
+    except MeshtasticConnectionError as err:
+        _LOGGER.error("Meshtastic connection error: %s", err)
+        return MeshtasticDevice(
+            connection_type=config.connection_type,
+            serial_port=config.serial_port,
+            tcp_host=config.tcp_host,
+            tcp_port=config.tcp_port,
+            error=str(err),
         )
-        node_details.role = (
-            (radio_config_dict.get("preferences") or {}).get("role")
-            or node_info.get("role")
-        )
-        node_details.route_table_size = len(nodes)
-
-        ble_info = my_info_dict.get("ble") or my_info_dict.get("ble_info") or {}
-        node_details.ble_mac = ble_info.get("macaddr") or ble_info.get("address") or ble_info.get("mac")
-        node_details.ble_name = ble_info.get("name") or ble_info.get("hostname")
-
-        node_details.channels = _extract_channel_names(channels)
-        if node_details.channels:
-            node_details.channel = node_details.channels[0]
-
-        metrics_dict = my_info_dict.get("node_metrics") or {}
-        node_details.rssi = (
-            metrics_dict.get("rssi")
-            or metrics_dict.get("rx_rssi")
-            or metrics_dict.get("last_heard_rssi")
-        )
-        node_details.snr = (
-            metrics_dict.get("snr")
-            or metrics_dict.get("rx_snr")
-            or metrics_dict.get("last_heard_snr")
-        )
-        node_details.airtime_utilization = (
-            metrics_dict.get("air_util_tx")
-            or metrics_dict.get("air_util")
-            or metrics_dict.get("airtime")
+    except Exception as err:  # pragma: no cover - defensive logging
+        _LOGGER.exception("Unexpected error while updating Meshtastic data")
+        return MeshtasticDevice(
+            connection_type=config.connection_type,
+            serial_port=config.serial_port,
+            tcp_host=config.tcp_host,
+            tcp_port=config.tcp_port,
+            error=str(err),
         )
 
-        # Attempt to derive metrics from the node table if missing
-        if (node_details.rssi is None or node_details.snr is None) and nodes:
-            my_node = nodes.get(node_details.node_num)
-            if my_node is not None:
-                node_dict = _protobuf_to_dict(my_node)
-                node_details.rssi = node_details.rssi or node_dict.get("snr") or node_dict.get("rx_rssi")
-                node_details.snr = node_details.snr or node_dict.get("snr") or node_dict.get("rx_snr")
-
-        decoded = last_received_dict.get("decoded") or {}
-        node_details.last_message = (
-            decoded.get("text")
-            or decoded.get("payload")
-            or decoded.get("data")
-        )
-        node_details.last_sender = last_received_dict.get("from") or last_received_dict.get("from_id")
-        node_details.last_gateway = last_received_dict.get("gateway_id") or last_received_dict.get("rx_gateway")
-
-        return node_details
-    finally:
-        try:
-            interface.close()
-        except Exception:  # pragma: no cover - close best effort
-            _LOGGER.debug("Failed to close Meshtastic interface for %s", device_path, exc_info=True)
-
-
-def _extract_channel_names(channels: list[Any]) -> list[str]:
-    """Return a list of channel names from protobuf channel definitions."""
-    channel_names: list[str] = []
-    for channel in channels:
-        channel_dict = _protobuf_to_dict(channel)
-        name = (
-            (channel_dict.get("settings") or {}).get("name")
-            or channel_dict.get("name")
-        )
-        if name:
-            channel_names.append(name)
-    return channel_names

--- a/custom_components/meshtastic_usb/manifest.json
+++ b/custom_components/meshtastic_usb/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "meshtastic_usb",
-  "name": "Meshtastic USB",
+  "name": "Meshtastic",
   "version": "2024.04.25.1400",
   "documentation": "https://github.com/Skrap87/MeshtasticHA",
   "issue_tracker": "https://github.com/Skrap87/MeshtasticHA/issues",

--- a/custom_components/meshtastic_usb/sensor.py
+++ b/custom_components/meshtastic_usb/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for the Meshtastic USB integration."""
+"""Sensor platform for the Meshtastic integration."""
 
 from __future__ import annotations
 
@@ -6,26 +6,29 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE, TIME_SECONDS, UnitOfElectricPotential, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .connection import MeshtasticDevice, MeshtasticNodeDetails
 from .const import (
     ATTR_DEVICES,
     ATTR_ERROR,
+    ATTR_TCP,
     DOMAIN,
+    SENSOR_BATTERY_LEVEL,
+    SENSOR_BATTERY_VOLTAGE,
     SENSOR_CHANNEL,
     SENSOR_FIRMWARE,
     SENSOR_LAST_MESSAGE,
     SENSOR_NODE_ID,
     SENSOR_RSSI,
     SENSOR_SNR,
+    SENSOR_TEMPERATURE,
+    SENSOR_UPTIME,
 )
-from .coordinator import (
-    MeshtasticDevice,
-    MeshtasticNodeDetails,
-    MeshtasticUsbCoordinator,
-)
+from .coordinator import CoordinatorDeviceState, MeshtasticUsbCoordinator
 
 
 async def async_setup_entry(
@@ -33,74 +36,133 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Meshtastic USB sensor."""
-    coordinator: MeshtasticUsbCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        [
-            MeshtasticUsbSensor(coordinator),
-            MeshtasticFirmwareSensor(coordinator),
-            MeshtasticNodeIdSensor(coordinator),
-            MeshtasticChannelSensor(coordinator),
-            MeshtasticRssiSensor(coordinator),
-            MeshtasticSnrSensor(coordinator),
-            MeshtasticLastMessageSensor(coordinator),
-        ],
-        True,
-    )
+    """Set up Meshtastic sensors from a config entry."""
+    coordinator: MeshtasticUsbCoordinator = hass.data[DOMAIN]["coordinators"][
+        entry.entry_id
+    ]
+
+    entities: list[SensorEntity] = [
+        MeshtasticDeviceSensor(coordinator, entry),
+        MeshtasticFirmwareSensor(coordinator, entry),
+        MeshtasticNodeIdSensor(coordinator, entry),
+        MeshtasticChannelSensor(coordinator, entry),
+        MeshtasticRssiSensor(coordinator, entry),
+        MeshtasticSnrSensor(coordinator, entry),
+        MeshtasticLastMessageSensor(coordinator, entry),
+        MeshtasticBatteryLevelSensor(coordinator, entry),
+        MeshtasticBatteryVoltageSensor(coordinator, entry),
+        MeshtasticTemperatureSensor(coordinator, entry),
+        MeshtasticUptimeSensor(coordinator, entry),
+    ]
+
+    async_add_entities(entities, True)
 
 
 class MeshtasticCoordinatorEntity(CoordinatorEntity[MeshtasticUsbCoordinator]):
-    """Coordinator mixin with helper properties."""
+    """Common base for Meshtastic coordinator entities."""
 
-    def __init__(self, coordinator: MeshtasticUsbCoordinator) -> None:
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
+        self._entry = entry
+
+    @property
+    def _state(self) -> CoordinatorDeviceState | None:
+        return self.coordinator.data
+
+    @property
+    def _devices(self) -> list[MeshtasticDevice]:
+        state = self._state
+        if not state:
+            return []
+        return state.devices
 
     @property
     def _primary_device(self) -> MeshtasticDevice | None:
-        """Return the first device with node details."""
-        devices = self.coordinator.data or []
+        devices = self._devices
         for device in devices:
             if device.node is not None:
                 return device
         return devices[0] if devices else None
 
+    @property
+    def device_info(self) -> dict[str, Any]:
+        device = self._primary_device
+        identifier = self._entry.entry_id
+        if device and device.identifier != "unknown":
+            identifier = device.identifier
+        identifiers = {(DOMAIN, identifier)}
+        name = "Meshtastic"
+        model = None
+        sw_version = None
 
-class MeshtasticUsbSensor(MeshtasticCoordinatorEntity, SensorEntity):
-    """Sensor that exposes connected USB devices."""
+        if device:
+            if device.node:
+                node = device.node
+                if node.node_name and node.my_node_id:
+                    name = f"Meshtastic {node.node_name} ({node.my_node_id})"
+                elif node.node_name:
+                    name = f"Meshtastic {node.node_name}"
+                elif node.my_node_id:
+                    name = f"Meshtastic {node.my_node_id}"
+                model = node.hw_model
+                sw_version = node.firmware
+            elif device.serial_port:
+                name = f"Meshtastic Serial {device.serial_port}"
+            elif device.tcp_host:
+                port = device.tcp_port
+                name = f"Meshtastic {device.tcp_host}:{port}" if port else f"Meshtastic {device.tcp_host}"
 
-    _attr_icon = "mdi:usb-port"
-    _attr_name = "Meshtastic USB devices"
+        info: dict[str, Any] = {
+            "identifiers": identifiers,
+            "manufacturer": "Meshtastic",
+            "name": name,
+        }
+        if model:
+            info["model"] = model
+        if sw_version:
+            info["sw_version"] = sw_version
+        return info
+
+
+class MeshtasticDeviceSensor(MeshtasticCoordinatorEntity, SensorEntity):
+    """Sensor exposing the connection state."""
+
+    _attr_icon = "mdi:radio-tower"
     _attr_native_unit_of_measurement = "devices"
-    _attr_unique_id = "meshtastic_usb_devices"
+
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_name = "Meshtastic devices"
+        self._attr_unique_id = f"{entry.entry_id}_devices"
 
     @property
     def native_value(self) -> int:
-        """Return the number of connected USB devices."""
-        data = self.coordinator.data or []
-        return len(data)
+        devices = self._devices
+        if not devices:
+            return 0
+        available = [device for device in devices if device.node]
+        return len(available)
 
     @property
-    def extra_state_attributes(self) -> dict[str, list[dict[str, Any]]]:
-        """Return details about the connected USB devices."""
-        devices = []
-        for device in self.coordinator.data or []:
-            devices.append(device.as_dict())
-        return {ATTR_DEVICES: devices}
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {ATTR_DEVICES: [device.as_dict() for device in self._devices]}
 
 
 class MeshtasticNodeSensor(MeshtasticCoordinatorEntity, SensorEntity):
-    """Base class for sensors that expose Meshtastic node data."""
+    """Base class for sensors that read values from the node."""
 
     def __init__(
         self,
         coordinator: MeshtasticUsbCoordinator,
+        entry: ConfigEntry,
         sensor_key: str,
         name: str,
         icon: str | None = None,
     ) -> None:
-        super().__init__(coordinator)
-        self._attr_unique_id = f"meshtastic_usb_{sensor_key}"
+        super().__init__(coordinator, entry)
+        self._sensor_key = sensor_key
         self._attr_name = name
+        self._attr_unique_id = f"{entry.entry_id}_{sensor_key}"
         if icon:
             self._attr_icon = icon
 
@@ -127,6 +189,13 @@ class MeshtasticNodeSensor(MeshtasticCoordinatorEntity, SensorEntity):
         attrs: dict[str, Any] = {}
         if device.node:
             attrs.update(device.node.as_dict())
+        if device.serial_port:
+            attrs["serial_port"] = device.serial_port
+        if device.tcp_host:
+            attrs[ATTR_TCP] = {
+                "host": device.tcp_host,
+                "port": device.tcp_port,
+            }
         if device.error:
             attrs[ATTR_ERROR] = device.error
         return attrs
@@ -137,8 +206,8 @@ class MeshtasticFirmwareSensor(MeshtasticNodeSensor):
 
     _attr_icon = "mdi:chip"
 
-    def __init__(self, coordinator: MeshtasticUsbCoordinator) -> None:
-        super().__init__(coordinator, SENSOR_FIRMWARE, "Meshtastic firmware")
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_FIRMWARE, "Meshtastic firmware")
 
     def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
         return node.firmware
@@ -149,8 +218,8 @@ class MeshtasticNodeIdSensor(MeshtasticNodeSensor):
 
     _attr_icon = "mdi:identifier"
 
-    def __init__(self, coordinator: MeshtasticUsbCoordinator) -> None:
-        super().__init__(coordinator, SENSOR_NODE_ID, "Meshtastic node ID")
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_NODE_ID, "Meshtastic node ID")
 
     def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
         return node.my_node_id
@@ -159,35 +228,35 @@ class MeshtasticNodeIdSensor(MeshtasticNodeSensor):
 class MeshtasticChannelSensor(MeshtasticNodeSensor):
     """Sensor exposing the active channel."""
 
-    _attr_icon = "mdi:radio-tower"
+    _attr_icon = "mdi:radio"
 
-    def __init__(self, coordinator: MeshtasticUsbCoordinator) -> None:
-        super().__init__(coordinator, SENSOR_CHANNEL, "Meshtastic channel")
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_CHANNEL, "Meshtastic channel")
 
     def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
         return node.channel
 
 
 class MeshtasticRssiSensor(MeshtasticNodeSensor):
-    """Sensor exposing the RSSI metric."""
+    """Sensor exposing the RSSI value."""
 
-    _attr_icon = "mdi:signal"
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_icon = "mdi:signal"
 
-    def __init__(self, coordinator: MeshtasticUsbCoordinator) -> None:
-        super().__init__(coordinator, SENSOR_RSSI, "Meshtastic RSSI")
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_RSSI, "Meshtastic RSSI")
 
     def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
         return node.rssi
 
 
 class MeshtasticSnrSensor(MeshtasticNodeSensor):
-    """Sensor exposing the SNR metric."""
+    """Sensor exposing the SNR value."""
 
     _attr_icon = "mdi:chart-line"
 
-    def __init__(self, coordinator: MeshtasticUsbCoordinator) -> None:
-        super().__init__(coordinator, SENSOR_SNR, "Meshtastic SNR")
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_SNR, "Meshtastic SNR")
 
     def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
         return node.snr
@@ -198,15 +267,15 @@ class MeshtasticLastMessageSensor(MeshtasticNodeSensor):
 
     _attr_icon = "mdi:message-text"
 
-    def __init__(self, coordinator: MeshtasticUsbCoordinator) -> None:
-        super().__init__(coordinator, SENSOR_LAST_MESSAGE, "Meshtastic last message")
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_LAST_MESSAGE, "Meshtastic last message")
 
     def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
         return node.last_message
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        attrs = dict(super().extra_state_attributes)
+        attrs = super().extra_state_attributes
         device = self._primary_device
         if not device or not device.node:
             return attrs
@@ -214,6 +283,66 @@ class MeshtasticLastMessageSensor(MeshtasticNodeSensor):
             {
                 "last_sender": device.node.last_sender,
                 "last_gateway": device.node.last_gateway,
+                "last_message_type": device.node.last_message_type,
+                "last_message_time": device.node.last_message_time,
             }
         )
         return attrs
+
+
+class MeshtasticBatteryLevelSensor(MeshtasticNodeSensor):
+    """Sensor exposing the battery level."""
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_BATTERY_LEVEL, "Meshtastic battery")
+
+    def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
+        return node.battery_level
+
+
+class MeshtasticBatteryVoltageSensor(MeshtasticNodeSensor):
+    """Sensor exposing the battery voltage."""
+
+    _attr_device_class = SensorDeviceClass.VOLTAGE
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator,
+            entry,
+            SENSOR_BATTERY_VOLTAGE,
+            "Meshtastic battery voltage",
+        )
+
+    def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
+        return node.battery_voltage
+
+
+class MeshtasticTemperatureSensor(MeshtasticNodeSensor):
+    """Sensor exposing the device temperature."""
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_TEMPERATURE, "Meshtastic temperature")
+
+    def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
+        return node.temperature
+
+
+class MeshtasticUptimeSensor(MeshtasticNodeSensor):
+    """Sensor exposing node uptime in seconds."""
+
+    _attr_native_unit_of_measurement = TIME_SECONDS
+    _attr_icon = "mdi:clock-outline"
+
+    def __init__(self, coordinator: MeshtasticUsbCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry, SENSOR_UPTIME, "Meshtastic uptime")
+
+    def _value_from_node(self, node: MeshtasticNodeDetails) -> Any:
+        return node.uptime
+

--- a/custom_components/meshtastic_usb/services.yaml
+++ b/custom_components/meshtastic_usb/services.yaml
@@ -1,0 +1,49 @@
+send_message:
+  name: Send text message
+  description: Send a text message through the configured Meshtastic node.
+  fields:
+    entry_id:
+      name: Config entry
+      description: Optional config entry ID when multiple nodes are configured.
+      example: "a1b2c3d4e5f6"
+    target:
+      name: Target node
+      description: Destination node ID or leave empty for broadcast.
+      example: "!abcd1234"
+    message:
+      name: Message
+      description: Text payload to send.
+      required: true
+      example: "Hello from Home Assistant"
+
+reboot:
+  name: Reboot node
+  description: Reboot the selected Meshtastic node.
+  fields:
+    entry_id:
+      name: Config entry
+      description: Optional config entry ID when multiple nodes are configured.
+      example: "a1b2c3d4e5f6"
+
+set_channel:
+  name: Set primary channel
+  description: Change the primary channel by name on the Meshtastic node.
+  fields:
+    entry_id:
+      name: Config entry
+      description: Optional config entry ID when multiple nodes are configured.
+      example: "a1b2c3d4e5f6"
+    channel_name:
+      name: Channel name
+      description: Name of the channel to set as primary.
+      required: true
+      example: "LongFast"
+
+refresh:
+  name: Refresh node data
+  description: Request an immediate update from the Meshtastic node.
+  fields:
+    entry_id:
+      name: Config entry
+      description: Optional config entry ID when multiple nodes are configured.
+      example: "a1b2c3d4e5f6"

--- a/custom_components/meshtastic_usb/strings.json
+++ b/custom_components/meshtastic_usb/strings.json
@@ -2,12 +2,70 @@
   "config": {
     "step": {
       "user": {
-        "title": "Set up Meshtastic USB",
-        "description": "Start monitoring connected USB devices."
+        "title": "Set up Meshtastic",
+        "description": "Choose how the Meshtastic node is connected.",
+        "data": {
+          "connection_type": "Connection type"
+        }
+      },
+      "serial": {
+        "title": "Configure serial connection",
+        "description": "Select the USB serial port and update interval.",
+        "data": {
+          "serial_port": "Serial port",
+          "update_interval": "Update interval (seconds)"
+        }
+      },
+      "tcp": {
+        "title": "Configure TCP connection",
+        "description": "Select how to configure the Meshtastic TCP node."
+      },
+      "tcp_manual": {
+        "title": "Manual TCP configuration",
+        "description": "Enter the host, port, and update interval for the Meshtastic node.",
+        "data": {
+          "tcp_host": "Host",
+          "tcp_port": "Port",
+          "update_interval": "Update interval (seconds)"
+        }
+      },
+      "tcp_discovery": {
+        "title": "Discover TCP devices",
+        "description": "Select one of the discovered Meshtastic nodes.",
+        "data": {
+          "device": "Device",
+          "update_interval": "Update interval (seconds)"
+        }
       }
     },
+    "menu": {
+      "tcp": {
+        "manual": "Enter host and port manually",
+        "discovery": "Discover devices on the network"
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to the Meshtastic node.",
+      "serial_port_not_found": "No Meshtastic-compatible serial device was found.",
+      "tcp_host_missing": "Host is required for TCP connections.",
+      "library_missing": "The Meshtastic Python library is not available.",
+      "serial_library_missing": "The pyserial library is not available.",
+      "no_devices_found": "No Meshtastic TCP devices were discovered.",
+      "device_not_found": "The selected device is no longer available."
+    },
     "abort": {
-      "single_instance_allowed": "Meshtastic USB is already configured."
+      "invalid_connection": "The selected connection type is not supported.",
+      "already_configured": "This Meshtastic node is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Meshtastic options",
+        "data": {
+          "update_interval": "Update interval (seconds)"
+        }
+      }
     }
   }
 }

--- a/custom_components/meshtastic_usb/translations/en.json
+++ b/custom_components/meshtastic_usb/translations/en.json
@@ -2,12 +2,70 @@
   "config": {
     "step": {
       "user": {
-        "title": "Set up Meshtastic USB",
-        "description": "Start monitoring connected USB devices."
+        "title": "Set up Meshtastic",
+        "description": "Choose how the Meshtastic node is connected.",
+        "data": {
+          "connection_type": "Connection type"
+        }
+      },
+      "serial": {
+        "title": "Configure serial connection",
+        "description": "Select the USB serial port and update interval.",
+        "data": {
+          "serial_port": "Serial port",
+          "update_interval": "Update interval (seconds)"
+        }
+      },
+      "tcp": {
+        "title": "Configure TCP connection",
+        "description": "Select how to configure the Meshtastic TCP node."
+      },
+      "tcp_manual": {
+        "title": "Manual TCP configuration",
+        "description": "Enter the host, port, and update interval for the Meshtastic node.",
+        "data": {
+          "tcp_host": "Host",
+          "tcp_port": "Port",
+          "update_interval": "Update interval (seconds)"
+        }
+      },
+      "tcp_discovery": {
+        "title": "Discover TCP devices",
+        "description": "Select one of the discovered Meshtastic nodes.",
+        "data": {
+          "device": "Device",
+          "update_interval": "Update interval (seconds)"
+        }
       }
     },
+    "menu": {
+      "tcp": {
+        "manual": "Enter host and port manually",
+        "discovery": "Discover devices on the network"
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to the Meshtastic node.",
+      "serial_port_not_found": "No Meshtastic-compatible serial device was found.",
+      "tcp_host_missing": "Host is required for TCP connections.",
+      "library_missing": "The Meshtastic Python library is not available.",
+      "serial_library_missing": "The pyserial library is not available.",
+      "no_devices_found": "No Meshtastic TCP devices were discovered.",
+      "device_not_found": "The selected device is no longer available."
+    },
     "abort": {
-      "single_instance_allowed": "Meshtastic USB is already configured."
+      "invalid_connection": "The selected connection type is not supported.",
+      "already_configured": "This Meshtastic node is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Meshtastic options",
+        "data": {
+          "update_interval": "Update interval (seconds)"
+        }
+      }
     }
   }
 }

--- a/custom_components/meshtastic_usb/version.py
+++ b/custom_components/meshtastic_usb/version.py
@@ -1,4 +1,4 @@
-"""Version information for the Meshtastic USB integration."""
+"""Version information for the Meshtastic integration."""
 
 from __future__ import annotations
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Meshtastic USB",
+  "name": "Meshtastic",
   "content_in_root": false,
   "filename": "README.md",
   "render_readme": true,


### PR DESCRIPTION
## Summary
- add a connection layer that supports serial and TCP Meshtastic nodes, including discovery and command helpers
- overhaul the config flow, coordinator, and sensors to handle per-node telemetry such as battery, temperature, and uptime
- register domain services and update documentation for sending messages, rebooting nodes, and network discovery options

## Testing
- python -m compileall custom_components/meshtastic_usb

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917b02fca588324899f4c94a63a0f10)